### PR TITLE
fix issue about multiple tables in DQT

### DIFF
--- a/picojdec.py
+++ b/picojdec.py
@@ -369,11 +369,11 @@ def parse_DQT(r, image):
         for k in range(64):
             q[k] = r.byte(n)
         print(f'  DQT[{t}]: Pq={pq} Tq={tq} Q_k={q}')
+        # register QuantizationTable
+        image['QT'][tq] = q
         lq -= 1 + 64 * n
         t += 1
     assert lq == 0, "invalid DQT payload"
-    # register QuantizationTable
-    image['QT'][tq] = q
 
 
 # Huffman table-specification


### PR DESCRIPTION
![test](https://user-images.githubusercontent.com/1194653/57199922-dbe27980-6fbf-11e9-8c46-b27fedb980b6.jpeg)
test.jpeg

```
$ python3 picojdec.py test.jpeg
SOI
APP1: La=24 Ap=b'Exif\x00\x00II*\x00\x08\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
DQT: Lq=132
  DQT[0]: Pq=0 Tq=0 Q_k=[6, 4, 4, 4, 5, 4, 6, 5, 5, 6, 9, 6, 5, 6, 9, 11, 8, 6, 6, 8, 11, 12, 10, 10, 11, 10, 10, 12, 16, 12, 12, 12, 12, 12, 12, 16, 12, 14, 15, 16, 15, 14, 12, 19, 19, 20, 20, 19, 19, 28, 27, 27, 27, 28, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31]
  DQT[1]: Pq=0 Tq=1 Q_k=[7, 7, 7, 13, 12, 13, 24, 16, 16, 24, 26, 21, 17, 21, 26, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31]
SOF0: Lf=17 P=8 Y=64 X=64 Nf=3
  Component[0]: C=1 H=1 V=1 Tq=0
  Component[1]: C=2 H=1 V=1 Tq=1
  Component[2]: C=3 H=1 V=1 Tq=1
Traceback (most recent call last):
  File "picojdec.py", line 559, in <module>
    main(*args)
  File "picojdec.py", line 549, in main
    image = parse_stream(r)
  File "picojdec.py", line 477, in parse_stream
    frame = parse_SOFn(r, n, image)
  File "picojdec.py", line 313, in parse_SOFn
    assert image['QT'][c['Tq']], "QuantizationTable not found"
AssertionError: QuantizationTable not found
```